### PR TITLE
Wire frasermolyneux-copilot MCP server (pinned to v0.1.0)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -14,3 +14,9 @@
 - Azure auth: workflows rely on GitHub environment OIDC vars (`AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_SUBSCRIPTION_ID`). Static Web App deploy pulls API key via `az staticwebapp secrets list` in workflows.
 - Docs: [docs/development-workflows.md](docs/development-workflows.md) documents branch/label rules, concurrency guards, and quick reference for pipelines.
 - Patterns: keep markdown/front matter in posts; exclude infra/editor folders via `_config.yml` `exclude` list. Static site assets stay under `src`; infra under `terraform` to mirror other platform static sites.
+
+## Org conventions via MCP (when available)
+
+If a `frasermolyneux-copilot` MCP server is configured in your client (`.vscode/mcp.json`, the GitHub Copilot coding-agent MCP config at `.github/copilot/mcp_config.json`, or an equivalent stdio MCP wire-up), **prefer its tools** over your own assumptions when answering questions about org standards, branching, workflows, Terraform, .NET projects, Azure patterns, or shared library / platform consumption contracts. The tool surface is `list_instructions`, `get_instruction`, `search_instructions`, plus the matching `_prompts` and `_agents` equivalents (seven tools total). The catalog source-of-truth lives in `frasermolyneux/.github-copilot` — see `mcp-server/README.md` there for the tool contract.
+
+This is **complementary** to the file-load model: if `./.github-copilot/` is checked out in the runner (per `copilot-setup-steps.yml`), continue to read those files directly. If both are available, prefer MCP for freshness. If no MCP server is configured in your client, treat this section as a no-op and fall back to the file paths above.

--- a/.github/copilot/mcp_config.json
+++ b/.github/copilot/mcp_config.json
@@ -1,0 +1,13 @@
+{
+  "mcpServers": {
+    "frasermolyneux-copilot": {
+      "type": "local",
+      "command": "node",
+      "args": [".github-copilot/mcp-server/dist/index.js"],
+      "env": {
+        "GH_COPILOT_CONTENT_ROOT": ".github-copilot"
+      },
+      "tools": ["*"]
+    }
+  }
+}

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -32,6 +32,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: frasermolyneux/.github-copilot
+          ref: refs/tags/v0.1.0
           path: .github-copilot
 
       - name: Setup Ruby
@@ -40,3 +41,14 @@ jobs:
           ruby-version: '3.3'
           bundler-cache: true
           working-directory: src
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20.x
+
+      - name: Build MCP server
+        working-directory: .github-copilot/mcp-server
+        run: |
+          npm ci
+          npm run build

--- a/README.md
+++ b/README.md
@@ -26,3 +26,7 @@ Please read the [contributing](CONTRIBUTING.md) guidance; this is a learning and
 
 Please read the [security](SECURITY.md) guidance; I am always open to security feedback through email or opening an issue.
 
+## Local dev: MCP wire-up
+
+This repo is wired to the shared `frasermolyneux-copilot` MCP server (pinned to `frasermolyneux/.github-copilot@v0.1.0`). The setup workflow (`.github/workflows/copilot-setup-steps.yml`) checks the shared catalog into `.github-copilot/`, installs Node 20.x, and builds the server; the Copilot coding agent loads it via `.github/copilot/mcp_config.json`. See [`.github-copilot/mcp-server/README.md`](https://github.com/frasermolyneux/.github-copilot/blob/v0.1.0/mcp-server/README.md) for the tool contract, content-root resolution, and per-client wire-up snippets.
+


### PR DESCRIPTION
Wires the shared `frasermolyneux-copilot` MCP catalog server into this repo so MCP-capable Copilot clients (VS Code Copilot Chat, the coding agent, Copilot CLI) can call `list/get/search` for instructions, prompts, and agents against `frasermolyneux/.github-copilot` instead of guessing org conventions. Mirrors the template already shipped to `portal-core`, pinned to tag `v0.1.0`.

### Changes
- **`.github/workflows/copilot-setup-steps.yml`** - pin the existing shared-copilot checkout to `ref: refs/tags/v0.1.0`, then add `actions/setup-node@v6` (Node 20.x) and a `Build MCP server` step that runs `npm ci && npm run build` in `.github-copilot/mcp-server`. Existing Ruby setup, triggers, and permissions are untouched.
- **`.github/copilot/mcp_config.json`** (new) - declares the local `frasermolyneux-copilot` node server for the GitHub Copilot coding agent, pointing at the built `dist/index.js` and setting `GH_COPILOT_CONTENT_ROOT=.github-copilot`.
- **`.github/copilot-instructions.md`** - appends the canonical `## Org conventions via MCP (when available)` snippet. Text is byte-identical to the source-of-truth at `frasermolyneux/.github-copilot@v0.1.0:.github/instructions/metadata.copilot-instructions.instructions.md` (SHA256 `30269E10F9D2B1AC9705E1021AAC1B4C17D196104C7C53B428AF60C0821FF023` in its LF form).
- **`README.md`** - short `## Local dev: MCP wire-up` section pointing to the shared `mcp-server/README.md` at the v0.1.0 tag rather than duplicating the docs.

### Notes for reviewers
- `AGENTS.md` is deliberately **not** added here. The standard 5-touch-point rollout calls for it, but the file does not exist in this repo and the rollout spec forbids inventing canonical metadata files from scratch. Bootstrapping `AGENTS.md` is owned by the `update-project-metadata` agent and tracked as a follow-up.
- The shared catalog is pinned via mutable git tag (`v0.1.0`). If org-wide reproducibility becomes a concern, swap the `ref:` for the resolved commit SHA (with the tag in a comment). Consistent decision needed across all 5 consumer repos.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>